### PR TITLE
Duplicate objects

### DIFF
--- a/Categories/NSManagedObjectContext+KFData.m
+++ b/Categories/NSManagedObjectContext+KFData.m
@@ -52,7 +52,9 @@
     NSError *error;
 
     if ([self hasChanges]) {
-        if ([self save:&error]) {
+        if ([self obtainPermanentIDsForObjects:[[self insertedObjects] allObjects] error:&error] &&
+            [self save:&error])
+        {
             NSManagedObjectContext *parentContext = [self parentContext];
 
             if (parentContext) {


### PR DESCRIPTION
We can reliably reproduce duplicate objects, however one will have a permanent objectID and one has a temporary one. I have made changes that fetch a permanent objectID upon each new object creation, see branch 'gw'.

Read this stackoverflow post for additional information: http://stackoverflow.com/questions/11321717/core-data-could-not-fullfil-fault-for-object-after-obtainpermanantids
