### PR TITLE
Allow KFDataTableViewController subclasses to disable row editing

### DIFF
--- a/KFData/UI/KFDataTableViewDataSource.h
+++ b/KFData/UI/KFDataTableViewDataSource.h
@@ -32,6 +32,15 @@
 @property (nonatomic, strong, readonly) NSFetchRequest *fetchRequest;
 @property (nonatomic, strong, readonly) NSFetchedResultsController *fetchedResultsController;
 
+/** By default all rows are assumed to be editable. Set this to NO to disable 
+ the default. You are still able to override tableView:canEditRowAtIndexPath: 
+ in your subclass to provide customised editing logic.
+ @warning This is a 'global' setting. Setting this to NO will disable row 
+ editing for all rows. Do not call super if you want to provide custom edit
+ logic.
+ */
+@property (nonatomic, assign) BOOL allowRowEditing;
+
 - (instancetype)initWithTableView:(UITableView *)tableView
              managedObjectContext:(NSManagedObjectContext *)managedObjectContext
                      fetchRequest:(NSFetchRequest *)fetchRequest

--- a/KFData/UI/KFDataTableViewDataSource.m
+++ b/KFData/UI/KFDataTableViewDataSource.m
@@ -29,6 +29,8 @@
 
         _fetchedResultsController = fetchedResultsController;
         _fetchedResultsController.delegate = self;
+
+        _allowRowEditing = YES; // YES is the default of not overriding tableView:canEditRowAtIndexPath: (see UITableViewDataSource documentation)
     }
 
     return self;
@@ -188,7 +190,9 @@
 //    return index;
 //}
 
-//- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath;
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    return self.allowRowEditing;
+}
 //- (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath;
 //- (void)tableView:(UITableView *)tableView moveRowAtIndexPath:(NSIndexPath *)sourceIndexPath toIndexPath:(NSIndexPath *)destinationIndexPath;
 


### PR DESCRIPTION
This enables a simple KFDataTableViewController subclass to disable row editing without needing to subclass KFDataTableViewDataSource only to override one method.
