### PR TITLE
[Bug Fix] Return the correct data source class

### DIFF
--- a/KFData/UI/KFDataTableViewController.m
+++ b/KFData/UI/KFDataTableViewController.m
@@ -33,7 +33,7 @@
 #pragma mark -
 
 - (Class)dataSourceClass {
-    return [KFDataTableViewDataSource class];
+    return [KFDataTableViewDataSourceController class];
 }
 
 - (void)setDataSource:(KFDataTableViewDataSource *)dataSource {


### PR DESCRIPTION
KFDataTableViewController is returning the standard KFDataTableViewDataSource class instead of it's subclass. The result is an exception thrown by KFDataTableViewDataSource::tableView:cellForRowAtIndexPath: because it cannot find an implementation.
