### PR TITLE
Expose KFDataCollectionViewDataSourceController class

### DIFF
--- a/KFData/UI/KFDataCollectionViewController.h
+++ b/KFData/UI/KFDataCollectionViewController.h
@@ -13,9 +13,17 @@
 #import <UIKit/UIKit.h>
 #import <CoreData/CoreData.h>
 
-@class KFDataCollectionViewDataSource;
+#import "KFDataCollectionViewDataSource.h"
+
 @class KFObjectManager;
 
+/** KFDataCollectionViewDataSourceController is a simple data source that routes the calls for collectionView:cellForItemAtIndexPath: and collectionView:viewForSupplementaryElementOfKind:atIndexPath:
+ to the collection view delegate. It is an easy method of providing the cell construction methods without the need for a custom data source class.
+ */
+
+@interface KFDataCollectionViewDataSourceController : KFDataCollectionViewDataSource
+
+@end
 
 /** KFDataCollectionViewController is a generic controller base that uses
  KFDataCollectionViewDataSource as a data source. Providing helper methods

--- a/KFData/UI/KFDataCollectionViewController.m
+++ b/KFData/UI/KFDataCollectionViewController.m
@@ -7,13 +7,8 @@
 //
 
 #import "KFDataCollectionViewController.h"
-#import "KFDataCollectionViewDataSource.h"
 
 #if defined(__IPHONE_OS_VERSION_MIN_REQUIRED)
-
-@interface KFDataCollectionViewDataSourceController : KFDataCollectionViewDataSource
-
-@end
 
 @implementation KFDataCollectionViewDataSourceController
 


### PR DESCRIPTION
The class was never used internally nor was it being exposed for others to implement.

@kylef it was either this or make `KFDataCollectionViewController` return it as the default data source class. Since this is a bit of a hack and only really provided for legacy transition I thought it best to rather expose the class than force it's use.
